### PR TITLE
innerRef - setValue for type='custom'

### DIFF
--- a/__tests__/Form.spec.js
+++ b/__tests__/Form.spec.js
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  cleanup,
+  fireEvent,
+  waitFor,
+  act
+} from "@testing-library/react";
 
 import { SimpleFormTestSumbission } from "./helpers/components/SimpleFormTestSumbission";
 import { CollectionDynamicCart } from "./helpers/components/CollectionDynamicField";
@@ -12,7 +18,7 @@ import {
 } from "./helpers/components/ComplexForm";
 import { mountForm } from "./helpers/utils/mountForm";
 
-import { Input, Select, Collection, TextArea } from "./../src";
+import { Input, Select, Collection, TextArea, Form } from "./../src";
 
 const dataTestid = "email";
 const typeInput = "text";
@@ -512,6 +518,18 @@ describe("Component => Form", () => {
       { name: "mickey" },
       { name: "foo" }
     );
+  });
+
+  it("should accept an innerRef prop to access to DOM", () => {
+    const name = "foo";
+    const ref = React.createRef();
+
+    act(() => {
+      render(<Form innerRef={ref} name={name} />);
+    });
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current.name).toBe(name);
   });
 
   it("should run reducer functions applied to Form on fields removal", () => {

--- a/__tests__/Input.spec.js
+++ b/__tests__/Input.spec.js
@@ -180,6 +180,23 @@ describe("Component => Input", () => {
     expect(fileInputMultiple.files[1]).toStrictEqual(files[1]);
   });
 
+  it("should accept an innerRef prop to access to DOM", () => {
+    const type = "text";
+    const name = "email";
+    const ref = React.createRef();
+    const children = [
+      <Input key="1" innerRef={ref} type={type} name={name} value="1" />
+    ];
+    act(() => {
+      mountForm({ children });
+    });
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current.type).toBe(type);
+    expect(ref.current.value).toBe("1");
+    expect(ref.current.name).toBe(name);
+  });
+
   it("should trigger onChange event when the Input value changes", () => {
     const onChangeInput = jest.fn(value => value);
     const children = [
@@ -518,11 +535,7 @@ describe("Component => Input", () => {
     expect(checkbox.checked).toBe(true);
 
     onInit.mockClear();
-    children = [<Input key="1" type="custom" name={name} value={{ a: 1 }} />];
-    mountForm({ props, children });
-    expect(onInit).toHaveBeenCalledWith({ [name]: { a: 1 } }, true);
 
-    onInit.mockClear();
     children = [
       <Input
         key="1"

--- a/__tests__/Select.spec.js
+++ b/__tests__/Select.spec.js
@@ -126,6 +126,26 @@ describe("Component => Select", () => {
     expect(onReset).toHaveBeenCalledWith({ [name]: ["1", "2"] }, true);
   });
 
+  it("should accept an innerRef prop to access to DOM", () => {
+    const name = "test";
+    const value = "1";
+    const ref = React.createRef();
+    const children = [
+      <Select key="1" innerRef={ref} name={name} value={value}>
+        <option value="" />
+        <option value={value}>{value}</option>
+      </Select>
+    ];
+
+    act(() => {
+      mountForm({ children });
+    });
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current.value).toBe("1");
+    expect(ref.current.name).toBe(name);
+  });
+
   it("should use a reducer to reduce the Select value", () => {
     const props = { onInit };
     const reducer = value => value + 2;

--- a/__tests__/TextArea.spec.js
+++ b/__tests__/TextArea.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, cleanup } from "@testing-library/react";
+import { fireEvent, cleanup, act } from "@testing-library/react";
 import { mountForm } from "./helpers/utils/mountForm";
 import { TextArea } from "./../src";
 
@@ -28,5 +28,23 @@ describe("Component => TextArea", () => {
     fireEvent.change(textArea, { target: { value } });
     expect(onChange).toHaveBeenCalledWith({ [name]: value }, true);
     expect(textArea.value).toBe(value);
+  });
+
+  it("should accept an innerRef prop to access to DOM", () => {
+    const type = "textarea";
+    const name = "foo";
+    const ref = React.createRef();
+    const children = [
+      <TextArea key="1" innerRef={ref} name={name} value="1" />
+    ];
+
+    act(() => {
+      mountForm({ children });
+    });
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current.type).toBe(type);
+    expect(ref.current.value).toBe("1");
+    expect(ref.current.name).toBe(name);
   });
 });

--- a/__tests__/helpers/components/CustomField.jsx
+++ b/__tests__/helpers/components/CustomField.jsx
@@ -10,7 +10,13 @@ export const CustomField = withIndex(
     valueToChange = "5"
   }) => {
     const props = useField({ type, name, value });
-    const onChange = () => props.onChange({ target: { value: valueToChange } });
+    const onChange = () => {
+      if (type === "custom") {
+        props.setValue(valueToChange);
+      } else {
+        props.onChange({ target: { value: valueToChange } });
+      }
+    };
     useEffect(() => {
       jestFN(props.value);
     }, []);

--- a/__tests__/hooks/useField.spec.js
+++ b/__tests__/hooks/useField.spec.js
@@ -55,9 +55,18 @@ describe("Hooks => useField", () => {
     const props = { onInit, onChange };
     const initial = { a: "test" };
     const jestFN = jest.fn();
+    const valueToChange = prev => {
+      return { ...prev, a: "BeBo" };
+    };
 
     const children = [
-      <CustomField key="1" name={name} value={initial} jestFN={jestFN} />
+      <CustomField
+        key="1"
+        valueToChange={valueToChange}
+        name={name}
+        value={initial}
+        jestFN={jestFN}
+      />
     ];
     const { getByTestId } = mountForm({ children, props });
 
@@ -70,7 +79,7 @@ describe("Hooks => useField", () => {
       fireEvent.click(buttonChange);
     });
 
-    expect(onChange).toHaveBeenCalledWith({ [name]: "5" }, true);
+    expect(onChange).toHaveBeenCalledWith({ [name]: { a: "BeBo" } }, true);
   });
 
   it("should render a Field of type text with an initial value passed as prop", () => {

--- a/docs/Collection.mdx
+++ b/docs/Collection.mdx
@@ -14,7 +14,7 @@ import { Collection, useValidation, Input, useAsyncValidation } from './../src';
 It creates a nested piece of state within a Form. <br />
 A Collection can be of type: **object** or **array**.
 
-### Props
+## Props
 
 **`object`**: boolean
 
@@ -24,13 +24,15 @@ It creates a collecion of type **object** if "true".
 
 It creates a collecion of type **array** if "true".
 
-**`name`**: string - (except for **Collection** children of Collection of type array)
+**`name`**: string
 
-A field's name in Usetheform state.
+A field's name in Usetheform state. <br />
+If your Collection is rendered within a `<Collection array />`, **name** is not allowed as prop.
 
-**`index`**: string - (only for **Collection** children of Collection of type array)
+**`index`**: string
 
-A field's index in array Collection.
+A field's index in array Collection. <br />
+**index** is only allowed If your Collection is rendered within a `<Collection array /> `. 
 
 **`touched`**: boolean
 

--- a/docs/Form.mdx
+++ b/docs/Form.mdx
@@ -10,7 +10,7 @@ import { Input } from './../src';
 # Form
 The Form is the most important component in Usetheform. It renders all the Fields and keeps synchronized the entire form state.
 
-### Props
+## Props
 
 **`onInit`**: function
 
@@ -80,6 +80,15 @@ Possible values:
 
  - An absolute URL - points to another web site (like action="http://www.example.com/example.htm")
  - A relative URL - points to a file within a web site (like action="example.htm")
+
+**`innerRef`**: object (a mutable ref object)
+
+When you need to access the underlying DOM node created by Form (e.g. to call focus), you can use a ref to store a reference to the form dom node.
+
+```javascript
+const ref = useRef(null)
+<Form innerRef={ref} name="form">...fields...</Form>
+```
 
 ## Basic usage
 

--- a/docs/FormContext.mdx
+++ b/docs/FormContext.mdx
@@ -11,7 +11,7 @@ import { Input, useForm } from './../src';
 
 It is a react component that provides a context of the "form" at wider level.
 
-### Props
+## Props
 
 **`onInit`**: function
 

--- a/docs/Input.mdx
+++ b/docs/Input.mdx
@@ -11,19 +11,21 @@ import { Input, useValidation, useAsyncValidation } from './../src';
 # Input
 It renders all the inputs of type listed at: [W3schools Input Types](https://www.w3schools.com/html/html_form_input_types.asp) and accepts as props any html attribute listed at: [Html Input Attributes](https://www.w3schools.com/tags/tag_input.asp).
 
-### Props
+## Props
 
 **`type`**: string
 
 Type listed at: [W3schools Input Types](https://www.w3schools.com/html/html_form_input_types.asp).
 
-**`name`**: string - (except for **Input** children of Collection of type array)
+**`name`**: string
 
-A field's name in Usetheform state.
+A field's name in Usetheform state. <br />
+If your Input is rendered within a `<Collection array />`, **name** is not allowed as prop.
 
-**`index`**: string - (only for **Input** children of Collection of type array)
+**`index`**: string
 
-A field's index in array Collection.
+A field's index in array Collection. <br />
+**index** is only allowed If your Input is rendered within a `<Collection array /> `. 
 
 **`value`**: string | number
 
@@ -47,6 +49,15 @@ If *true* validation messages (sync and async) will be showing only when the eve
  
 An array whose values correspond to different reducing functions.
 Reducers functions specify how the Input's value change.
+
+**`innerRef`**: object (a mutable ref object)
+
+When you need to access the underlying DOM node created by Input (e.g. to call focus), you can use a ref to store a reference to the input dom node.
+
+```javascript
+const ref = useRef(null)
+<Input innerRef={ref} type="text" name="test" />
+```
 
 ## Basic usage
 

--- a/docs/Select.mdx
+++ b/docs/Select.mdx
@@ -12,15 +12,17 @@ import { Select, useValidation, useAsyncValidation } from './../src';
 The *select* element is used to create a drop-down list. <br />
 It accepts as props any html attribute listed at: [Html Select Attributes](https://www.w3schools.com/tags/tag_select.asp).
 
-### Props
+## Props
 
-**`name`**: string - (except for **Select** children of Collection of type array)
+**`name`**: string
 
-A field's name in Usetheform state.
+A field's name in Usetheform state. <br />
+If your Select is rendered within a `<Collection array />`, **name** is not allowed as prop. 
 
-**`index`**: string - (only for **Select** children of Collection of type array)
+**`index`**: string
 
-A field's index in array Collection.
+A field's index in array Collection. <br />
+**index** is only allowed If your Select is rendered within a `<Collection array /> `.
 
 **`value`**: string
 
@@ -32,6 +34,10 @@ A field that has been touched/visited. Default value *false*.
 
 If *true* validation messages (sync and async) will be showing only when the event onBlur of the field is triggered by the user action.
 
+**`multiple`**: boolean
+
+When present, it specifies that multiple options can be selected at once. Default value *false*. 
+
 **`reducers`**: array | function
 
 ```javascript
@@ -40,6 +46,15 @@ If *true* validation messages (sync and async) will be showing only when the eve
  
 An array whose values correspond to different reducing functions.
 Reducers functions specify how the Select's value change.
+
+**`innerRef`**: object (a mutable ref object)
+
+When you need to access the underlying DOM node created by Select (e.g. to call focus), you can use a ref to store a reference to the select dom node.
+
+```javascript
+const ref = useRef(null)
+<Select innerRef={ref} name="test">...options...</Select>
+```
 
 ## Basic usage 
 

--- a/docs/TextArea.mdx
+++ b/docs/TextArea.mdx
@@ -11,15 +11,17 @@ import { TextArea, useValidation, useAsyncValidation } from './../src';
 # TextArea
 It renders a *textarea* element: [W3schools Textarea](https://www.w3schools.com/tags/tag_textarea.asp) and accepts as props any html attribute listed at: [Html Textarea Attributes](https://www.w3schools.com/tags/tag_textarea.asp).
 
-### Props
+## Props
 
-**`name`**: string - (except for **TextArea** children of Collection of type array)
+**`name`**: string
 
-A field's name in Usetheform state.
+A field's name in Usetheform state. <br />
+If your TextArea is rendered within a `<Collection array />`, **name** is not allowed as prop.
 
-**`index`**: string - (only for **TextArea** children of Collection of type array)
+**`index`**: string
 
-A field's index in array Collection.
+A field's index in array Collection. <br />
+**index** is only allowed If your TextArea is rendered within a `<Collection array /> `.
 
 **`value`**: string
 
@@ -39,6 +41,15 @@ If *true* validation messages (sync and async) will be showing only when the eve
  
 An array whose values correspond to different reducing functions.
 Reducers functions specify how the TextArea's value change.
+
+**`innerRef`**: object (a mutable ref object)
+
+When you need to access the underlying DOM node created by TextArea (e.g. to call focus), you can use a ref to store a reference to the textarea dom node.
+
+```javascript
+const ref = useRef(null)
+<TextArea innerRef={ref} name="textarea" value="test" />
+```
 
 ## Basic usage
 

--- a/docs/helpers/Form.jsx
+++ b/docs/helpers/Form.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { default as FormUsetheform } from "./../../src";
 import JSONTree from "react-json-tree";
 
-export const Form = ({ onInit, onChange, ...props }) => {
+export const Form = ({ onInit, onChange, onReset, ...props }) => {
   const [formState, setState] = useState({});
   const onInitFN = state => {
     onInit && onInit(state);
@@ -12,9 +12,19 @@ export const Form = ({ onInit, onChange, ...props }) => {
     onChange && onChange(state);
     setState(state);
   };
+
+  const onResetFN = state => {
+    onReset && onReset(state);
+    setState(state);
+  };
   return (
     <>
-      <FormUsetheform onInit={onInitFN} onChange={onChangeFN} {...props}>
+      <FormUsetheform
+        onInit={onInitFN}
+        onReset={onResetFN}
+        onChange={onChangeFN}
+        {...props}
+      >
         {props.children}
       </FormUsetheform>
       <div

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -48,7 +48,13 @@ npm install --save usetheform
 
 ## Author
 
-- Antonio Pangallo [@antonio_pangall](https://twitter.com/antonio_pangall)
+Antonio Pangallo [@antonio_pangall](https://twitter.com/antonio_pangall)
+
+## Contributing
+
+🎉 First off, thanks for taking the time to contribute! 🎉
+
+We would like to encourage everyone to help and support this library by contributing. See the [CONTRIBUTING file](https://github.com/iusehooks/usetheform/blob/master/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/useAsyncValidation.mdx
+++ b/docs/useAsyncValidation.mdx
@@ -8,7 +8,7 @@ import { Form } from "./helpers/Form";
 import { Input, useAsyncValidation } from './../src';
 
 # useAsyncValidation
-It is a custom hook function which provides the async validation logic to any Field.
+`useAsyncValidation(validator: Function)` provides the async validation logic to any Field.
 
 ```javascript
   const [asyncStatus, validationAsyncAttr] = useAsyncValidation(fn);
@@ -16,7 +16,7 @@ It is a custom hook function which provides the async validation logic to any Fi
 
 ## Arguments
 
-**`fn`**: function
+**`validator`**: function
 
   - A function which receive the value of the field and return a promise.
 

--- a/docs/useCollection.mdx
+++ b/docs/useCollection.mdx
@@ -4,7 +4,7 @@ menu: Hooks
 ---
 
 # useCollection
-It is a custom React hook which allows to build a custom Collection.
+`useCollection(options: Object)` allows to build a custom Collection.
 A Collection can be of type: *object* or *array*.
 
 ```javascript
@@ -23,13 +23,15 @@ A Collection can be of type: *object* or *array*.
 
   It creates a collecion of type **array** if "true".
 
-  - **`name`**: string - (except for children of Collection of type array)
+  - **`name`**: string
 
-  A field's name in Usetheform state.
+  A field's name in Usetheform state. <br />
+  If it is rendered within a `<Collection array />`, **name** is not allowed as prop.
 
-  - **`index`**: string - (only for children of Collection of type array)
+  - **`index`**: string
 
-  A field's index in array Collection.
+  A field's index in array Collection. <br />
+  **index** is only allowed If it is rendered within a `<Collection array /> `.
 
   - **`value`**: array | object
 

--- a/docs/useField.mdx
+++ b/docs/useField.mdx
@@ -4,7 +4,7 @@ menu: Hooks
 ---
 
 # useField
-It is a custom React hook which allows to build a custom input primitives.
+`useField(options: Object)` allows to build a custom input primitives.
 
 ```javascript
   const fieldInputProps = useField(options)
@@ -18,13 +18,15 @@ It is a custom React hook which allows to build a custom input primitives.
   
   Strings accepted: [W3schools Input Types](https://www.w3schools.com/html/html_form_input_types.asp) - "select" - "custom"
 
-  - **`name`**: string - (except for children of Collection of type array)
+  - **`name`**: string
 
-  A field's name in Usetheform state.
+  A field's name in Usetheform state. <br />
+  If your Field is rendered within a `<Collection array />`, **name** is not allowed as prop.
 
-  - **`index`**: string - (only for children of Collection of type array)
+  - **`index`**: string
 
-  A field's index in array Collection.
+  A field's index in array Collection. <br />
+  **index** is only allowed If your Field is rendered within a `<Collection array /> `.
 
   - **`value`**: string | number | object (only for type="custom")
 
@@ -32,7 +34,11 @@ It is a custom React hook which allows to build a custom input primitives.
 
   - **`checked`**: boolean
 
-  Specifies that an *input* element should be pre-selected or not (for type="checkbox" or type="radio").
+  Specifies that an *input* element should be pre-selected or not (for type="checkbox" or type="radio"). Default value *false*.
+
+  - **`multiple`**: boolean
+
+  Valid only for type="select", when present, it specifies that multiple options can be selected at once. Default value *false*.
 
   - **`touched`**: boolean
 
@@ -70,13 +76,13 @@ const CustomInput = props => {
 ```
 
 ```javascript
-const CustomField = ({ name, value = { a: "2" } }) => {
-  const props = useField({ type: "custom", name, value });
-  const onChange = () => props.onChange({ target: { value: { a: "1" } } });
+const CustomField = ({ name, initialValue = { a: "2" } }) => {
+  const { value, setValue } = useField({ type: "custom", name, value: initialValue });
+  const onChange = () => setValue(prev => ({ ...prev, a: "1" }));
   return (
     <div>
       <pre>
-        <code>{JSON.stringify(props.value)}</code>
+        <code>{JSON.stringify(value)}</code>
       </pre>
       <button type="button" onClick={onChange}>
         Change Value

--- a/docs/useMultipleForm.mdx
+++ b/docs/useMultipleForm.mdx
@@ -8,7 +8,7 @@ import { Form } from "./helpers/Form";
 import { Input, useMultipleForm } from './../src';
 
 # useMultipleForm
-`useMultipleForm(callback)` is a custom React hook which provides the logic to handle the implementation of wizards.
+`useMultipleForm(callback: Function)` provides the logic to handle the implementation of wizards.
 
 ```javascript
   const [getWizardStatus, wizardApi] = useMultipleForm(callback);

--- a/docs/useValidation.mdx
+++ b/docs/useValidation.mdx
@@ -8,10 +8,10 @@ import { Form } from "./helpers/Form";
 import { Input, useValidation } from './../src';
 
 # useValidation
-It is a custom hook function which provides the validation logic to any Field.
+`useValidation(functions: Array)` provides the validation logic to any Field.
 
 ```javascript
-  const [status, validation] = useValidation([...functions])
+  const [status, validation] = useValidation([fn1, fn2, ...fnN])
 ```
 
 ## Arguments

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
   base: "/usetheform",
-  ignore: ["README.md", "LICENSE.md"],
+  ignore: ["README.md", "LICENSE.md", "CONTRIBUTING.md"],
   menu: ["Introduction", "Components", "Hooks"],
   themesDir: "./docs",
   themeConfig: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usetheform",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "React library for composing declarative forms in React and managing their state.",
   "main": "./build/index.js",
   "module": "./build/es/index.js",

--- a/src/Form.js
+++ b/src/Form.js
@@ -15,6 +15,7 @@ function Form({
   _onMultipleForm_, // Private API
   name,
   action,
+  innerRef,
   ...rest
 }) {
   const { onSubmitForm, ...props } = useForm({
@@ -42,7 +43,13 @@ function Form({
 
   return (
     <Context.Provider value={ctx}>
-      <form action={action} onSubmit={onSubmitForm} {...rest} name={name}>
+      <form
+        action={action}
+        onSubmit={onSubmitForm}
+        {...rest}
+        name={name}
+        ref={innerRef}
+      >
         {children}
       </form>
     </Context.Provider>

--- a/src/Input.js
+++ b/src/Input.js
@@ -20,6 +20,7 @@ export const Input = withIndex(function Input({
   touched,
   multiple,
   reducers,
+  innerRef,
   ...extraProps
 }) {
   const props = useField({
@@ -42,5 +43,5 @@ export const Input = withIndex(function Input({
     multiple
   });
 
-  return <input {...extraProps} {...props} />;
+  return <input {...extraProps} {...props} ref={innerRef} />;
 });

--- a/src/Select.js
+++ b/src/Select.js
@@ -19,6 +19,7 @@ export const Select = withIndex(function Select({
   value,
   touched,
   reducers,
+  innerRef,
   ...extraProps
 }) {
   const props = useField({
@@ -41,7 +42,7 @@ export const Select = withIndex(function Select({
   });
 
   return (
-    <select {...extraProps} {...props}>
+    <select {...extraProps} {...props} ref={innerRef}>
       {children}
     </select>
   );

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -17,6 +17,7 @@ export const TextArea = withIndex(function TextArea({
   value,
   touched,
   reducers,
+  innerRef,
   ...extraProps
 }) {
   const props = useField({
@@ -37,5 +38,5 @@ export const TextArea = withIndex(function TextArea({
     reducers
   });
 
-  return <textarea {...extraProps} {...props} />;
+  return <textarea {...extraProps} {...props} ref={innerRef} />;
 });

--- a/src/hooks/commons/useValidationFunction.js
+++ b/src/hooks/commons/useValidationFunction.js
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import { passValidation } from "./../../utils/passValidation";
 import { getValidationMsg } from "./../../utils/getValidationMsg";
 
-export function useValidationFunction(validators) {
+export function useValidationFunction(validators = []) {
   const validationMsg = useRef(undefined);
   const validationObj = useRef(null);
   const validationFN = useRef((value, stateForm) => {

--- a/src/hooks/useObject.js
+++ b/src/hooks/useObject.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, useMemo } from "react";
 import { useOwnContext } from "./useOwnContext";
 import { useNameProp } from "./commons/useNameProp";
 import { useMapFields } from "./useMapFields";
@@ -15,6 +15,7 @@ import { noop } from "./../utils/noop";
 
 const initArray = [];
 const initObject = {};
+const validatorsDefault = [];
 
 export function useObject(props) {
   const context = useOwnContext();
@@ -24,8 +25,8 @@ export function useObject(props) {
     index,
     type,
     value: initValue,
-    reducers = [],
-    validators: validatorsFuncs = [],
+    reducers,
+    validators: validatorsFuncs = validatorsDefault,
     onValidation = noop,
     resetSyncErr = noop,
     resetAsyncErr = noop,
@@ -56,7 +57,7 @@ export function useObject(props) {
     type
   );
 
-  const { current: applyReducers } = useRef(chainReducers(reducers));
+  const applyReducers = useMemo(() => chainReducers(reducers), []);
 
   const isMounted = useRef(false);
   const stillMounted = useCallback(() => isMounted.current, []);

--- a/src/utils/chainReducers.js
+++ b/src/utils/chainReducers.js
@@ -1,6 +1,6 @@
 import { noop } from "./noop";
 
-export function chainReducers(reducers) {
+export function chainReducers(reducers = []) {
   if (typeof reducers === "function") {
     return reducers;
   }


### PR DESCRIPTION
## Improvement:

- innerRef prop can be passed to Form - Input - Select - TextArea 
- setValue  added to useField({ type="custom"}) 

### Example:
```javascript
const CustomField = ({ name }) => {
  const { value, setValue } = useField({ type: "custom", name, value: "5" });
  const onSetValue = () => setValue(prev => ++prev)
  
  return (
    <pre>
      <code data-testid="output">{JSON.stringify(value)}</code>
      <button type="button" onClick={onSetValue}>Set Value</button>
    </pre>
  );
};

function App() {
  const formRef = useRef();
  const inputRef = useRef();

  return (
    <Form innerRef={formRef} >
      <Input  innerRef={inputRef}  type="text" name="user" value="BeBo" />
    </Form>
  );
}
```